### PR TITLE
Remove potentially unneeded entry

### DIFF
--- a/landscape/devl/maps/sites.map
+++ b/landscape/devl/maps/sites.map
@@ -1996,7 +1996,6 @@ _/writing content ;
 _/writingprogram content ;
 _/wtbu content ;
 _/wwildman content ;
-_/www-test.bu.edu content ;
 _/wwwv content ;
 _/xyz content ;
 _/xzhou content ;


### PR DESCRIPTION
This entry seems like it might just be from parsing AFS to make the original list and isn't needed? But I'm not positive it isn't actually needed and used in some way not obvious to me.

There is a similar entry in the TEST `sites.map`:

https://github.com/bu-ist/webrouter-nonprod/blob/test/landscape/test/maps/sites.map#L426

and in **PROD** as well:

https://github.com/bu-ist/webrouter-prod/blob/prod/landscape/prod/maps/sites.map#L416

And the URLs do work, sort of:

http://www-devl.bu.edu/www-test.bu.edu/

http://www-test.bu.edu/www-test.bu.edu/

http://www.bu.edu/www-test.bu.edu/