### PR TITLE
These two sites should go to WordPress as PROD already goes there

### DIFF
--- a/landscape/test/maps/sites.map
+++ b/landscape/test/maps/sites.map
@@ -110,9 +110,6 @@ _/explore phpbin ;
 _/maps/livebus phpbin ;
 _/bumobile phpbin ;
 
-_/marcom content ;
-_/interactive-design content ;
-
 ####### From stub files/directory scan
 
 _/jamdocs content ;  # top-level


### PR DESCRIPTION
FYI Steve, no review. On merge webrouter will start updating the route for marcom and interactive-design in TEST to also go to WP.