### PR TITLE
Remove proposaldevelopment static content entry.

### DIFF
--- a/landscape/devl/maps/sites.map
+++ b/landscape/devl/maps/sites.map
@@ -152,7 +152,7 @@ interactive-design content ;
   cashelpdesk content ;  # top-level
   case-melville content ;  # top-level
   campaignkickoff content ;  # top-level
-  cas/magazine content ;  # 
+  cas/magazine content ;  #
   castle content ;  # top-level
   catholic content ;  # top-level
   casstudentacademiclife content ;  # top-level
@@ -441,8 +441,8 @@ interactive-design content ;
   wellness content ;  # top-level
   webmail content ;  # top-level
   websummit content ;  # top-level
-  webteam/mgburns content ;  # 
-  webteam/awbauer content ;  # 
+  webteam/mgburns content ;  #
+  webteam/awbauer content ;  #
   webteam/projects content ; #match ignore_prod.cms
   weddings content ;  # top-level
   weblogin content ;  # top-level
@@ -458,7 +458,7 @@ interactive-design content ;
   writing content ;  # top-level
   wgrimes content ;  # top-level
   wgs content ;  # top-level
-  wpmu/static content ;  # 
+  wpmu/static content ;  #
   wpnet content ;  # top-level
   wptraining content ;  # top-level
 ##TODO: get phpmap entry for wp-deploy and put in separate file
@@ -691,7 +691,7 @@ interactive-design content ;
   adminsc content ;  # top-level
   admissionsstatic content ;  # top-level
   adlab content ;  # top-level
-  admissions/applicantlink content ;  # 
+  admissions/applicantlink content ;  #
   auctions content ;  # top-level
   autismconnections content ;  # top-level
   autism content ;  # top-level
@@ -840,7 +840,7 @@ interactive-design content ;
   meller content ;  # top-level
   metmarcom content ;  # top-level
   medschool content ;  # top-level
-  met/homepage content ;  # 
+  met/homepage content ;  #
   metropolitan content ;  # top-level
   medalumni content ;  # top-level
   metit content ;  # top-level
@@ -1021,7 +1021,7 @@ interactive-design content ;
   homiletical-theology-project content ;  # top-level
   homeimages content ;  # top-level
   homepage2 content ;  # top-level
-  hr/documents content ;  # 
+  hr/documents content ;  #
   hrc content ;  # top-level
   hrpi content ;  # top-level
   hre content ;  # top-level
@@ -1460,8 +1460,8 @@ interactive-design content ;
   remember content ;  # top-level
   retired content ;  # top-level
   resnet content ;  # top-level
-  research/wp-assets content ;  # 
-  research/email content ;  # 
+  research/wp-assets content ;  #
+  research/email content ;  #
   reunion content ;  # top-level
   resources content ;  # top-level
   robots.txt content ;  # top-level
@@ -1473,7 +1473,7 @@ interactive-design content ;
   rocket content ;  # top-level
   rrtcout content ;  # top-level
   rl content ;  # top-level
-  rpm/panos content ;  # 
+  rpm/panos content ;  #
 ##TODO: get phpmap entry for rpm-agreements and put in separate file
 # skipping rp18p.GIF as we should only add the redirect2lower if necessary
   rsg content ;  # top-level
@@ -1638,9 +1638,9 @@ interactive-design content ;
   fhs content ;  # top-level
   fhcmi content ;  # top-level
   finance content ;  # top-level
-  finaid/status_documents content ;  # 
-  finaid/pdfs content ;  # 
-  finaid/fedfunds content ;  # 
+  finaid/status_documents content ;  #
+  finaid/pdfs content ;  #
+  finaid/fedfunds content ;  #
   finplanners content ;  # top-level
   firesafety content ;  # top-level
   firstpoint content ;  # top-level
@@ -1708,8 +1708,8 @@ interactive-design content ;
   laverdes content ;  # top-level
   lamovie content ;  # top-level
   old.law content ;  # top-level
-  law/workingpapers-archive content ;  # 
-  law/journals-archive content ;  # 
+  law/workingpapers-archive content ;  #
+  law/journals-archive content ;  #
   laprogram content ;  # top-level
   lawyearbooks content ;  # top-level
 ##TODO: get phpmap entry for law-pub and put in separate file
@@ -1817,7 +1817,7 @@ interactive-design content ;
   paadmissions content ;  # top-level
   parentfund content ;  # top-level
   padova content ;  # top-level
-  parking/dbtemplates content ;  # 
+  parking/dbtemplates content ;  #
   pace content ;  # top-level
   payment content ;  # top-level
   pm content ;  # top-level
@@ -1858,7 +1858,6 @@ interactive-design content ;
   prerelease content ;  # top-level
   president content ;  # top-level
   projectgo content ;  # top-level
-  proposaldevelopment content ;  # top-level
   prism content ;  # top-level
   professorvoices content ;  # top-level
   premodern content ;  # top-level
@@ -1948,9 +1947,9 @@ interactive-design content ;
   tanglewoodtwo content ;  # top-level
   tanglewood content ;  # top-level
   talks content ;  # top-level
-  tmp-orc/wp-assets content ;  # 
+  tmp-orc/wp-assets content ;  #
   tml content ;  # top-level
-  tmp-admissions/wp-assets content ;  # 
+  tmp-admissions/wp-assets content ;  #
   tmp-webcentral content ;  # top-level
   tv content ;  # top-level
   thedash content ;  # top-level
@@ -1994,16 +1993,16 @@ interactive-design content ;
   techweb content ;  # top-level
   terriertoasts content ;  # top-level
   telecom content ;  # top-level
-  today/common content ;  # 
-  today/media content ;  # 
-  today/bubooks content ;  # 
-  today/frozenfour content ;  # 
-  today/blasts content ;  # 
-  today/commencement content ;  # 
-  today/v2-devl content ;  # 
-  today/news content ;  # 
-  today/buniverse content ;  # 
-  today/v2 content ;  # 
+  today/common content ;  #
+  today/media content ;  #
+  today/bubooks content ;  #
+  today/frozenfour content ;  #
+  today/blasts content ;  #
+  today/commencement content ;  #
+  today/v2-devl content ;  #
+  today/news content ;  #
+  today/buniverse content ;  #
+  today/v2 content ;  #
   tol content ;  # top-level
   tokyo content ;  # top-level
   today-spash content ;  # top-level
@@ -2163,7 +2162,7 @@ interactive-design content ;
   software content ;  # top-level
   south content ;  # top-level
   sourceguide content ;  # top-level
-  sourcing/wp-protected content ;  # 
+  sourcing/wp-protected content ;  #
   sociology content ;  # top-level
   srp content ;  # top-level
   sfa content ;  # top-level
@@ -2333,7 +2332,7 @@ interactive-design content ;
   deafautism content ;  # top-level
   #whole_staging_site_in.cms content ;  # top-level
   doubleit content ;  # top-level
-  dos/facebook content ;  # 
+  dos/facebook content ;  #
   double-it content ;  # top-level
   drts content ;  # top-level
   dresden content ;  # top-level
@@ -2479,7 +2478,7 @@ interactive-design content ;
   behaviorallab content ;  # top-level
   botlab content ;  # top-level
   bonrc content ;  # top-level
-  bostonia/wpassets content ;  # 
+  bostonia/wpassets content ;  #
   bostonroc content ;  # top-level
   books content ;  # top-level
   bostonscholars content ;  # top-level
@@ -2595,8 +2594,8 @@ interactive-design content ;
 # skipping BUFELLOW as we should only add the redirect2lower if necessary
 # skipping BUCDE as we should only add the redirect2lower if necessary
 # skipping BUILD as we should only add the redirect2lower if necessary
-### 1933 content 
-### 160 wordpress 
-### 16 app 
-### 1 type 
-### 558 redirect2lower 
+### 1933 content
+### 160 wordpress
+### 16 app
+### 1 type
+### 558 redirect2lower

--- a/landscape/qa/maps/sites.map
+++ b/landscape/qa/maps/sites.map
@@ -2,7 +2,7 @@ _/version 20180202 ;
 
 # items from the Apache configuration
 _/htbin legacy ;
-_/studentlink redirect_asis ; 
+_/studentlink redirect_asis ;
 
 # UIS content
 _/uis content ;
@@ -1845,7 +1845,6 @@ _/prudential content ;
 _/prevmedresidency content ;
 ## premodern: wordpress
 ## professorvoices: wordpress
-_/proposaldevelopment content ;
 ## presidential-functions: wordpress
 ## prehealth: wordpress
 _/preservation content ;

--- a/landscape/syst/maps/sites.map
+++ b/landscape/syst/maps/sites.map
@@ -2,7 +2,7 @@ _/version 20180719 ;
 
 # items from the Apache configuration
 _/htbin legacy ;
-_/studentlink redirect_asis ; 
+_/studentlink redirect_asis ;
 
 # UIS content
 _/uis content ;
@@ -1845,7 +1845,6 @@ _/prudential content ;
 _/prevmedresidency content ;
 ## premodern: wordpress
 ## professorvoices: wordpress
-_/proposaldevelopment content ;
 ## presidential-functions: wordpress
 ## prehealth: wordpress
 _/preservation content ;


### PR DESCRIPTION
Removed 3 'proposaldevelopment' entries from devl, qa and syst. My editor auto-removed trailing whitespace so I left that in as well.