### PR TITLE
Remove www-test.bu.edu as a static content entry from TEST

### DIFF
--- a/landscape/test/maps/sites.map
+++ b/landscape/test/maps/sites.map
@@ -349,7 +349,6 @@ _/wcp content ;
 _/wcbct2010 content ;
 _/wcrew content ;
 _/wwwv content ;
-_/www-test.bu.edu content ;
 _/wwildman content ;
 _/wara content ;
 _/washintern content ;


### PR DESCRIPTION
See CHG041586 and https://github.com/bu-ist/webrouter-nonprod/pull/13 for more details