### PR TITLE
Update sites.map

### DIFF
--- a/landscape/test/maps/sites.map
+++ b/landscape/test/maps/sites.map
@@ -1261,7 +1261,6 @@ _/payroll content ;
 _/pc content ;
 _/pcms content ;
 _/pcsc content ;
-_/pdc content ;
 _/peeradvising content ;
 _/peermentor content ;
 _/pehc content ;


### PR DESCRIPTION
http://www-test.bu.edu/pdc/ is a wordpress site. Remove it from site map to route through wordpress backend