### PR TITLE
specific route for index.html

### DIFF
--- a/landscape/syst/hosts.map.erb
+++ b/landscape/syst/hosts.map.erb
@@ -35,8 +35,6 @@ content-cache ist-w3-content-syst101.bu.edu ;
 # S3 home bucket in web2cloud-nonprod account
 aws_home buaws-websites-homepage-test.s3.amazonaws.com ;
 
-# These entries are necessary to map to specific URLs in the /home space:
-#
-# No longer necessary
-#aws_home_index homepage-devl.s3-website-us-east-1.amazonaws.com/home/index.html ;
+# Needed to specifically handle index.html
+aws_home_index buaws-websites-homepage-test.s3.amazonaws.com/index.html ;
 

--- a/landscape/syst/maps/sites.map
+++ b/landscape/syst/maps/sites.map
@@ -137,7 +137,7 @@ _/rrtcout content ;
 ## rs: wordpress
 _/rss content ;
 _/rsg content ;
-_/index.html aws_home ;
+_/index.html aws_home_index ;
 _/index2.html content ;
 _/inst-tech content ;
 _/index3.html content ;


### PR DESCRIPTION
Without it, S3 delivers a manifest of the contents of the bucket.