### PR TITLE
Devl homepage and preview links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #FROM buist/websites-webrouter-base:2018.04.23
 #FROM buist/websites-webrouter-base:2018.06.26
 #FROM buist/websites-webrouter-base:2018.07.03
-FROM buist/websites-webrouter-base:2018.07.11
+FROM buist/websites-webrouter-base:2019.07.02
 
 # for now this is our split and everything below this is for a different location
 #

--- a/landscape/devl/hosts.map.erb
+++ b/landscape/devl/hosts.map.erb
@@ -25,14 +25,6 @@ uiscgi_app <%= ENV['BACKEND_UISCGI_APP'] || "ist-uiscgi-app-#{ENV['LANDSCAPE']}.
 uiscgi_content <%= ENV['BACKEND_UISCGI_CONTENT'] || "ist-uiscgi-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 # ###
-# The following backend types provide the homepage in S3.
-# There are multiple entries because the the homepage needs to map to
-# a subdirectory on the S3 bucket.
-#
-# This aws_homepage bucket is used for everything that maps normally:
-aws_home buaws-websites-homepage-devl.s3-website-us-east-1.amazonaws.com ;
-
-# These entries are necessary to map to specific URLs in the /home space:
-#
-aws_home_index buaws-websites-homepage-devl.s3-website-us-east-1.amazonaws.com/home/index.html ;
+# The following backend provides the homepage in S3.
+aws_home buaws-websites-homepage-test.s3-website-us-east-1.amazonaws.com ;
 

--- a/landscape/devl/hosts.map.erb
+++ b/landscape/devl/hosts.map.erb
@@ -26,5 +26,5 @@ uiscgi_content <%= ENV['BACKEND_UISCGI_CONTENT'] || "ist-uiscgi-content-#{ENV['L
 
 # ###
 # The following backend provides the homepage in S3.
-aws_home buaws-websites-homepage-test.s3-website-us-east-1.amazonaws.com ;
+aws_home buaws-websites-homepage-devl.s3-website-us-east-1.amazonaws.com ;
 

--- a/landscape/devl/maps/cachecontrol.map
+++ b/landscape/devl/maps/cachecontrol.map
@@ -11,3 +11,5 @@
   # no-cache header on protected content.
   content "no-cache, no-store" ;
 
+  # set specific max-age for the home page
+   aws_home "max-age=1800" ;

--- a/landscape/devl/maps/sites.map
+++ b/landscape/devl/maps/sites.map
@@ -930,6 +930,7 @@ _/hockey-task-force content ;
 _/hockeygolf content ;
 _/holmul content ;
 _/home aws_home ;
+_/index.html aws_home ;
 _/home-media content ;
 _/homecoming content ;
 _/homeimages content ;


### PR DESCRIPTION
Adds homepage routing to be consistent with other environments.  Also updates the docker image to handle preview links for the root WordPress site.