### PR TITLE
Updates for Shibboleth auth

### DIFF
--- a/landscape/devl/maps/sites.map
+++ b/landscape/devl/maps/sites.map
@@ -13,6 +13,9 @@ _/nisdev phpbin ;
 
 # These mappings are needed for Shibboleth authentication
 _/saml/content content ;
+#_/saml/wp-app wordpress ; -- default not required
+# djgannon: 2019.0913 -- weblogin retirement project
+_/saml/wp-assets wpassets ;
 
 # DegreeAdvice needs to be added
 # we should make a third party table for http backend services (maybe)

--- a/landscape/devl/maps/sites.map
+++ b/landscape/devl/maps/sites.map
@@ -11,11 +11,20 @@ _/maps phpbin ;
 _/bufellow/db-admin django ;
 _/nisdev phpbin ;
 
-# These mappings are needed for Shibboleth authentication
+
+###############################################
+# Shibboleth:
+
+# After successful Shibboleth authentication, the Shibboleth IdP needs
+# to redirect the visitor to the backend that requested the
+# authentication. If it was wpassets authenticating, the request needs
+# to land back on the wpassets backend. We do that by sending to
+# www.bu.edu/saml/BACKEND-HERE
+
 _/saml/content content ;
-#_/saml/wp-app wordpress ; -- default not required
-# djgannon: 2019.0913 -- weblogin retirement project
+_/saml/wp-app wordpress ;  # Not required, but let's be explicit here.
 _/saml/wp-assets wpassets ;
+###############################################
 
 # DegreeAdvice needs to be added
 # we should make a third party table for http backend services (maybe)


### PR DESCRIPTION
This allows Shibboleth authentication to occur on the wpassets backend (in the same way it is already setup to work on the content backend), and makes explicit that it should work on wordpress backend (even though that is the default, so technically that one would've worked either way).