### PR TITLE
revise buwd routing

### DIFF
--- a/landscape/qa/maps/vhosts.map
+++ b/landscape/qa/maps/vhosts.map
@@ -11,6 +11,4 @@
 # These are for the www-buwd sites
 www-buwd.bu.edu/link/bin buwd_uiscgi_app;
 
-www-buwd.bu.edu/link buwd_uiscgi_content;
-
-www-buwd.bu.edu buwd_content;
+www-buwd.bu.edu buwd_uiscgi_content;


### PR DESCRIPTION
Change to make www-buwd.bu.edu route only to the Link/UISCGI for testing; this will stop serving old pre-WP content from AFS over www-buwd.bu.edu