### PR TITLE
DockerHub login for test landscape

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,13 @@ phases:
       - $(aws ecr get-login --no-include-email )
       - TAG="$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"
       - IMAGEURI="${REPOSITORY_URI}:${TAG}"
+      - apt-get update
+      - apt-get install jq
+      - DOCKERHUB=$( aws secretsmanager get-secret-value --secret-id websites-webrouter/dockerhub-credentials --query SecretString )
+      - DOCKERHUB_PASSWORD=$(echo "$DOCKERHUB" | jq --raw-output . | jq -r .password )
+      - DOCKERHUB_USERNAME=$(echo "$DOCKERHUB" | jq --raw-output . | jq -r .user )
+      - echo "user=$DOCKERHUB_USERNAME"
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - docker build --build-arg "landscape=$LANDSCAPE" --tag "$IMAGEURI" .


### PR DESCRIPTION
This pull request adds the DockerHub login to the CodeBuild.  The iam stack for the landscape needs to be updated and the AWS SecretsManager needs to be created prior to merging this - see the instructions in 

https://github.com/bu-ist/web-router-infrastructure/pull/3

About deploying.